### PR TITLE
Use packetConn for reliable multicast

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ type ClientOption func(*clientOpts)
 // SelectIPTraffic selects the type of IP packets (IPv4, IPv6, or both) this
 // instance listens for.
 // This does not guarantee that only mDNS entries of this sepcific
-// type passes. E.g. typical mDNS packets distributed via IPv4, often contain
+// type passes. E.g. typical mDNS packets distributed via IPv4, may contain
 // both DNS A and AAAA entries.
 func SelectIPTraffic(t IPType) ClientOption {
 	return func(o *clientOpts) {
@@ -337,7 +337,6 @@ func (c *client) periodicQuery(ctx context.Context, params *LookupParams) error 
 
 	for {
 		// Do periodic query.
-		log.Println(">>> Doing periodic query..")
 		if err := c.query(params); err != nil {
 			// XXX: use own error handling instead of misuse of context
 			_, cancel := context.WithCancel(ctx)

--- a/client.go
+++ b/client.go
@@ -7,6 +7,9 @@ import (
 	"net"
 	"strings"
 
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -129,14 +132,14 @@ func defaultParams(service string) *LookupParams {
 
 // Client structure encapsulates both IPv4/IPv6 UDP connections.
 type client struct {
-	ipv4conn *net.UDPConn
-	ipv6conn *net.UDPConn
+	ipv4conn *ipv4.PacketConn
+	ipv6conn *ipv6.PacketConn
 }
 
 // Client structure constructor
 func newClient(opts clientOpts) (*client, error) {
 	// IPv4 interfaces
-	var ipv4conn *net.UDPConn
+	var ipv4conn *ipv4.PacketConn
 	if (opts.listenOn & IPv4) > 0 {
 		var err error
 		ipv4conn, err = joinUdp4Multicast(opts.ifaces)
@@ -145,7 +148,7 @@ func newClient(opts clientOpts) (*client, error) {
 		}
 	}
 	// IPv6 interfaces
-	var ipv6conn *net.UDPConn
+	var ipv6conn *ipv6.PacketConn
 	if (opts.listenOn & IPv6) > 0 {
 		var err error
 		ipv6conn, err = joinUdp6Multicast(opts.ifaces)
@@ -286,10 +289,25 @@ func (c *client) shutdown() {
 
 // Data receiving routine reads from connection, unpacks packets into dns.Msg
 // structures and sends them to a given msgCh channel
-func (c *client) recv(ctx context.Context, l *net.UDPConn, msgCh chan *dns.Msg) {
-	if l == nil {
+func (c *client) recv(ctx context.Context, l interface{}, msgCh chan *dns.Msg) {
+	var readFrom func([]byte) (n int, src net.Addr, err error)
+
+	switch pConn := l.(type) {
+	case *ipv6.PacketConn:
+		readFrom = func(b []byte) (n int, src net.Addr, err error) {
+			n, _, src, err = pConn.ReadFrom(b)
+			return
+		}
+	case *ipv4.PacketConn:
+		readFrom = func(b []byte) (n int, src net.Addr, err error) {
+			n, _, src, err = pConn.ReadFrom(b)
+			return
+		}
+
+	default:
 		return
 	}
+
 	buf := make([]byte, 65536)
 	var fatalErr error
 	for {
@@ -301,7 +319,7 @@ func (c *client) recv(ctx context.Context, l *net.UDPConn, msgCh chan *dns.Msg) 
 			return
 		}
 
-		n, _, err := l.ReadFrom(buf)
+		n, _, err := readFrom(buf)
 		if err != nil {
 			fatalErr = err
 			continue
@@ -400,10 +418,10 @@ func (c *client) sendQuery(msg *dns.Msg) error {
 		return err
 	}
 	if c.ipv4conn != nil {
-		c.ipv4conn.WriteTo(buf, ipv4Addr)
+		c.ipv4conn.WriteTo(buf, nil, ipv4Addr)
 	}
 	if c.ipv6conn != nil {
-		c.ipv6conn.WriteTo(buf, ipv6Addr)
+		c.ipv6conn.WriteTo(buf, nil, ipv6Addr)
 	}
 	return nil
 }

--- a/connection.go
+++ b/connection.go
@@ -36,7 +36,7 @@ var (
 	}
 )
 
-func joinUdp6Multicast(interfaces []net.Interface) (*net.UDPConn, error) {
+func joinUdp6Multicast(interfaces []net.Interface) (*ipv6.PacketConn, error) {
 	udpConn, err := net.ListenUDP("udp6", mdnsWildcardAddrIPv6)
 	if err != nil {
 		return nil, err
@@ -62,10 +62,10 @@ func joinUdp6Multicast(interfaces []net.Interface) (*net.UDPConn, error) {
 		return nil, fmt.Errorf("udp6: failed to join any of these interfaces: %v", interfaces)
 	}
 
-	return udpConn, nil
+	return pkConn, nil
 }
 
-func joinUdp4Multicast(interfaces []net.Interface) (*net.UDPConn, error) {
+func joinUdp4Multicast(interfaces []net.Interface) (*ipv4.PacketConn, error) {
 	udpConn, err := net.ListenUDP("udp4", mdnsWildcardAddrIPv4)
 	if err != nil {
 		log.Printf("[ERR] bonjour: Failed to bind to udp4 mutlicast: %v", err)
@@ -92,7 +92,7 @@ func joinUdp4Multicast(interfaces []net.Interface) (*net.UDPConn, error) {
 		return nil, fmt.Errorf("udp4: failed to join any of these interfaces: %v", interfaces)
 	}
 
-	return udpConn, nil
+	return pkConn, nil
 }
 
 func listMulticastInterfaces() []net.Interface {

--- a/server.go
+++ b/server.go
@@ -622,7 +622,7 @@ func (s *Server) multicastResponse(msg *dns.Msg) error {
 		var wcm ipv4.ControlMessage
 		for ifi := range s.ifaces {
 			wcm.IfIndex = s.ifaces[ifi].Index
-			s.ipv4conn.WriteTo(buf, nil, ipv4Addr)
+			s.ipv4conn.WriteTo(buf, &wcm, ipv4Addr)
 		}
 	}
 


### PR DESCRIPTION
This pull req tracks the progress for the transition to `PacketConn` from `UDPConn`.
A plain UDP connection only sends a multicast to one IPv4 and one IPv6 interface not knowing which one it will be.

`PacketConn` from [`golang.org/x/net/ipv6`](https://godoc.org/golang.org/x/net/ipv6)  provides reliable multicast support if multiple interfaces are present.
There is a `ControlMessage` struct that sets the outgoing interface for every UDP write.
