### PR TITLE
Allow clients to know about leaving servers

### DIFF
--- a/client.go
+++ b/client.go
@@ -262,6 +262,8 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 		if len(entries) > 0 {
 			for k, e := range entries {
 				if e.TTL == 0 {
+					// send the data such that the client knows the deletion
+					params.Entries <- e
 					delete(entries, k)
 					delete(sentEntries, k)
 					continue


### PR DESCRIPTION
When a server is leaving the network by sending a packet with TTL=0, let the clients about it.
