### PR TITLE
Added support for TTL expiry of entry.

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"strings"
 
@@ -84,13 +85,16 @@ func NewResolver(options ...ClientOption) (*Resolver, error) {
 
 // Browse for all services of a given type in a given domain.
 func (r *Resolver) Browse(ctx context.Context, service, domain string, entries chan<- *ServiceEntry) error {
+	b := Browser{}
+
 	params := defaultParams(service)
 	if domain != "" {
 		params.Domain = domain
 	}
 	params.Entries = entries
 
-	go r.c.mainloop(ctx, params)
+	b.cache = newEntryCache()
+	go r.c.mainloop(ctx, params, b.cache)
 
 	err := r.c.query(params)
 	if err != nil {
@@ -105,6 +109,59 @@ func (r *Resolver) Browse(ctx context.Context, service, domain string, entries c
 	return nil
 }
 
+// Browsev2 for all services of a given type in a given domain. When  entries are removed, events send to deletedEntries if non-nil.
+func (r *Resolver) Browsev2(ctx context.Context, service, domain string, entries, deletedEntries chan<- *ServiceEntry) error {
+	b := Browser{}
+	params := defaultParams(service)
+	if domain != "" {
+		params.Domain = domain
+	}
+	params.Entries = entries
+	params.DeletedEntries = deletedEntries
+
+	b.cache = newEntryCache()
+	go r.c.mainloop(ctx, params, b.cache)
+
+	err := r.c.query(params)
+	if err != nil {
+		_, cancel := context.WithCancel(ctx)
+		cancel()
+		return err
+	}
+	// If previous probe was ok, it should be fine now. In case of an error later on,
+	// the entries' queue is closed.
+	go r.c.periodicQuery(ctx, params)
+
+	return nil
+}
+
+// Browsev3 for all services of a given type in a given domain.
+func (r *Resolver) Browsev3(ctx context.Context, service, domain string, events chan<- *ServiceEvent) (*Browser, error) {
+	b := Browser{}
+
+	params := defaultParams(service)
+	if domain != "" {
+		params.Domain = domain
+	}
+	params.Entries = nil
+	params.Events = events
+
+	b.cache = newEntryCache()
+	go r.c.mainloop(ctx, params, b.cache)
+
+	err := r.c.query(params)
+	if err != nil {
+		_, cancel := context.WithCancel(ctx)
+		cancel()
+		return nil, err
+	}
+	// If previous probe was ok, it should be fine now. In case of an error later on,
+	// the entries' queue is closed.
+	go r.c.periodicQuery(ctx, params)
+
+	return &b, nil
+}
+
 // Lookup a specific service by its name and type in a given domain.
 func (r *Resolver) Lookup(ctx context.Context, instance, service, domain string, entries chan<- *ServiceEntry) error {
 	params := defaultParams(service)
@@ -114,7 +171,8 @@ func (r *Resolver) Lookup(ctx context.Context, instance, service, domain string,
 	}
 	params.Entries = entries
 
-	go r.c.mainloop(ctx, params)
+	sentEntries := newEntryCache()
+	go r.c.mainloop(ctx, params, sentEntries)
 
 	err := r.c.query(params)
 	if err != nil {
@@ -174,8 +232,46 @@ func newClient(opts clientOpts) (*client, error) {
 	}, nil
 }
 
+func newEntryCache() *entryCache {
+	return &entryCache{entries: make(map[string]*ServiceEntry)}
+}
+
+func computeExpiryDuration(entries map[string]*ServiceEntry) time.Duration {
+	var expDuration time.Duration
+	now := time.Now()
+
+	for _, v := range entries {
+		if v.refreshTime != nil {
+			d := v.refreshTime.Sub(now)
+			if expDuration == 0 {
+				expDuration = d
+			} else if d < expDuration {
+				expDuration = d
+			}
+		}
+		if v.expiryTime != nil {
+			d := v.expiryTime.Sub(now)
+
+			if expDuration == 0 {
+				expDuration = d
+			} else if d < expDuration {
+				expDuration = d
+			}
+		}
+	}
+	//log.Printf("computeExpiryDuration next %d nanoseconds", expDuration)
+	return expDuration
+}
+
 // Start listeners and waits for the shutdown signal from exit channel
-func (c *client) mainloop(ctx context.Context, params *LookupParams) {
+func (c *client) mainloop(ctx context.Context, params *LookupParams, sentEntries *entryCache) {
+	// create a time and stop it. we have a channel in the loop to look for timeouts
+	t := time.NewTimer(time.Second)
+	if !t.Stop() {
+		<-t.C
+	}
+	lastQueriedTime := time.Now()
+
 	// start listening for responses
 	msgCh := make(chan *dns.Msg, 32)
 	if c.ipv4conn != nil {
@@ -186,15 +282,53 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 	}
 
 	// Iterate through channels from listeners goroutines
-	var entries, sentEntries map[string]*ServiceEntry
-	sentEntries = make(map[string]*ServiceEntry)
+	var entries map[string]*ServiceEntry
 	for {
 		select {
 		case <-ctx.Done():
 			// Context expired. Notify subscriber that we are done here.
 			params.done()
 			c.shutdown()
+			if !t.Stop() {
+				<-t.C
+			}
 			return
+		case <-t.C:
+			//log.Printf("timer expired")
+
+			now := time.Now()
+			for k, v := range sentEntries.entries {
+				if (v.refreshTime != nil) && now.After(*v.refreshTime) {
+					//log.Printf("quering %s because of TTL refresh time expiry", k)
+
+					// query only if my previous query is older than a second
+					// If many entries are getting refreshed in a short time this should prevent flood to the network
+					if lastQueriedTime.Add(1 * time.Second).Before(time.Now()) {
+						c.query(params)
+						lastQueriedTime = time.Now()
+					}
+					v.refreshTime = nil
+				}
+
+				if (v.expiryTime != nil) && now.After(*v.expiryTime) {
+					//log.Printf("deleting %s because of TTL expiry", k)
+					delete(sentEntries.entries, k)
+
+					if params.DeletedEntries != nil {
+						params.DeletedEntries <- v
+					}
+
+					if params.Events != nil {
+						evt := ServiceEvent{ServiceEntry: *v, EventType: Removed}
+						params.Events <- &evt
+					}
+				}
+			}
+			nextExpiryDuration := computeExpiryDuration(sentEntries.entries)
+			if nextExpiryDuration != 0 {
+				t.Reset(nextExpiryDuration)
+			}
+
 		case msg := <-msgCh:
 			entries = make(map[string]*ServiceEntry)
 			sections := append(msg.Answer, msg.Ns...)
@@ -269,11 +403,26 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 		if len(entries) > 0 {
 			for k, e := range entries {
 				if e.TTL == 0 {
-					delete(entries, k)
-					delete(sentEntries, k)
+					//log.Printf("Received TTL==0 entry for %s", k)
+					if v, ok := sentEntries.entries[k]; ok {
+						// Expire the entry after 1 second. No need to refresh Entry with a query
+						et := time.Now().Add(1 * time.Second)
+						v.expiryTime = &et
+						v.refreshTime = nil
+					}
 					continue
 				}
-				if _, ok := sentEntries[k]; ok {
+				if v, ok := sentEntries.entries[k]; ok {
+					var rt, et time.Time
+					var frac float64
+
+					// random number between 75-85% of TTL expiry time. convert to float64 to overcome rounding errors
+					frac = (0.75 + rand.Float64()*0.1) * float64(e.TTL) * float64(time.Second)
+					rt = time.Now().Add(time.Duration(frac))
+					v.refreshTime = &rt
+
+					et = time.Now().Add(time.Duration(e.TTL) * time.Second)
+					v.expiryTime = &et
 					continue
 				}
 				// Require at least one resolved IP address for ServiceEntry
@@ -284,9 +433,21 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 				// Submit entry to subscriber and cache it.
 				// This is also a point to possibly stop probing actively for a
 				// service entry.
-				params.Entries <- e
-				sentEntries[k] = e
+				if params.Entries != nil {
+					params.Entries <- e
+				}
+				if params.Events != nil {
+					evt := ServiceEvent{ServiceEntry: *e, EventType: NewOrUpdated}
+					params.Events <- &evt
+				}
+				sentEntries.entries[k] = e
 				params.disableProbing()
+			}
+
+			nextExpiryDuration := computeExpiryDuration(sentEntries.entries)
+			if nextExpiryDuration != 0 {
+				t.Stop()
+				t.Reset(nextExpiryDuration)
 			}
 			// reset entries
 			entries = make(map[string]*ServiceEntry)
@@ -413,8 +574,8 @@ func (c *client) query(params *LookupParams) error {
 	m := new(dns.Msg)
 	if serviceInstanceName != "" {
 		m.Question = []dns.Question{
-			dns.Question{serviceInstanceName, dns.TypeSRV, dns.ClassINET},
-			dns.Question{serviceInstanceName, dns.TypeTXT, dns.ClassINET},
+			{serviceInstanceName, dns.TypeSRV, dns.ClassINET},
+			{serviceInstanceName, dns.TypeTXT, dns.ClassINET},
 		}
 		m.RecursionDesired = false
 	} else {

--- a/examples/register/server.go
+++ b/examples/register/server.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"log"
+	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"time"
@@ -18,12 +20,25 @@ var (
 	domain   = flag.String("domain", "local.", "Set the network domain. Default should be fine.")
 	port     = flag.Int("port", 42424, "Set the port the service is listening to.")
 	waitTime = flag.Int("wait", 10, "Duration in [s] to publish service for.")
+	intf     = flag.String("intf", "", "List of interfaces to register separated by ,")
 )
 
 func main() {
 	flag.Parse()
 
-	server, err := zeroconf.Register(*name, *service, *domain, *port, []string{"txtv=0", "lo=1", "la=2"}, nil)
+	zeroconf.DefaultTTL = 5
+	var intfList []net.Interface
+
+	if *intf != "" {
+		ifaces := strings.Split(*intf, ",")
+		for _, iface := range ifaces {
+			i, err := net.InterfaceByName(iface)
+			if err == nil {
+				intfList = append(intfList, *i)
+			}
+		}
+	}
+	server, err := zeroconf.Register(*name, *service, *domain, *port, []string{"txtv=0", "lo=1", "la=2"}, intfList)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/resolv/clientv3.go
+++ b/examples/resolv/clientv3.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"math/rand"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/grandcat/zeroconf"
+)
+
+var (
+	service  = flag.String("service", "_workstation._tcp", "Set the service category to look for devices.")
+	domain   = flag.String("domain", "local", "Set the search domain. For local networks, default is fine.")
+	waitTime = flag.Int("wait", 10, "Duration in [s] to run discovery.")
+	intf     = flag.String("intf", "", "List of interfaces to register separated by ,")
+)
+
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	flag.Parse()
+
+	var intfList []net.Interface
+	var err error
+
+	if *intf != "" {
+		ifaces := strings.Split(*intf, ",")
+		for _, iface := range ifaces {
+			i, err := net.InterfaceByName(iface)
+			if err == nil {
+				intfList = append(intfList, *i)
+			}
+		}
+	}
+
+	// Discover all services on the network (e.g. _workstation._tcp)
+
+	// a simpler call would be like below where we listen on all interfaces
+	// resolver, err := zeroconf.NewResolver(nil)
+	// However if we want to listen on selected interfaces only, use the call below
+	resolver, err := zeroconf.NewResolver(zeroconf.SelectIfaces(intfList))
+	if err != nil {
+		log.Fatalln("Failed to initialize resolver:", err.Error())
+	}
+
+	events := make(chan *zeroconf.ServiceEvent)
+	go func(results <-chan *zeroconf.ServiceEvent) {
+		for entry := range results {
+			log.Println("entry: ", entry)
+		}
+	}(events)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*waitTime))
+
+	defer cancel()
+	_, err = resolver.Browsev3(ctx, *service, *domain, events)
+	if err != nil {
+		log.Fatalln("Failed to browse:", err.Error())
+	}
+
+	<-ctx.Done()
+	// Wait some additional time to see debug messages on go routine shutdown.
+	time.Sleep(1 * time.Second)
+}

--- a/examples/resolv/clientv3_poll.go
+++ b/examples/resolv/clientv3_poll.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/grandcat/zeroconf"
+)
+
+var (
+	service  = flag.String("service", "_workstation._tcp", "Set the service category to look for devices.")
+	domain   = flag.String("domain", "local", "Set the search domain. For local networks, default is fine.")
+	waitTime = flag.Int("wait", 10, "Duration in [s] to run discovery.")
+	intf     = flag.String("intf", "", "List of interfaces to register separated by ,")
+)
+
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	flag.Parse()
+
+	var intfList []net.Interface
+	var err error
+
+	if *intf != "" {
+		ifaces := strings.Split(*intf, ",")
+		for _, iface := range ifaces {
+			i, err := net.InterfaceByName(iface)
+			if err == nil {
+				intfList = append(intfList, *i)
+			}
+		}
+	}
+
+	// Discover all services on the network (e.g. _workstation._tcp)
+
+	// a simpler call would be like below where we listen on all interfaces
+	// resolver, err := zeroconf.NewResolver(nil)
+	// However if we want to listen on selected interfaces only, use the call below
+	resolver, err := zeroconf.NewResolver(zeroconf.SelectIfaces(intfList))
+	if err != nil {
+		log.Fatalln("Failed to initialize resolver:", err.Error())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*waitTime))
+	var b *zeroconf.Browser
+
+	defer cancel()
+	b, err = resolver.Browsev3(ctx, *service, *domain, nil)
+	if err != nil {
+		log.Fatalln("Failed to browse:", err.Error())
+	}
+
+	<-ctx.Done()
+	fmt.Printf("cached entries: %+v\n", b.Entries())
+	// Wait some additional time to see debug messages on go routine shutdown.
+	time.Sleep(1 * time.Second)
+}

--- a/server.go
+++ b/server.go
@@ -16,6 +16,10 @@ import (
 	"github.com/miekg/dns"
 )
 
+var (
+	DefaultTTL uint32 = 3200
+)
+
 const (
 	// Number of Multicast responses sent for a query message (default: 1 < x < 9)
 	multicastRepitions = 2
@@ -192,7 +196,7 @@ func newServer(ifaces []net.Interface) (*Server, error) {
 		ipv4conn: ipv4conn,
 		ipv6conn: ipv6conn,
 		ifaces:   ifaces,
-		ttl:      3200,
+		ttl:      DefaultTTL,
 	}
 
 	return s, nil


### PR DESCRIPTION
Added support for TTL handling.
Before the entry is removed, query is made to server. Only when there is
no response, then entry is removed after TTL expiry.

Handle TTL==0 message as per standard. Wait for 1 second before purging
the entry.

Added Browsev3() API : This enabled the user of API to know if a service
is updated or deleted. Also enables the caller to query the current
Cache in addition to maintaining the channel for events.

Browsev2 API - a different version of API.
Not needed but including to generate any discussion needed.
If you agree - will remove all traces of this Browsev2 and resubmit the pull request.

Added examples for Browsev3