### PR TITLE
declarations for ServiceEvent, Browsev3

### DIFF
--- a/client.go
+++ b/client.go
@@ -450,3 +450,16 @@ func (c *client) sendQuery(msg *dns.Msg) error {
 	}
 	return nil
 }
+
+// Browsev3 - A new type of browser which keeps a local cache of network services
+//    As events happen in network, including TTL expiry or new host joins, the event is returned in the channel
+func (r *Resolver) Browsev3(ctx context.Context, service, domain string, events chan<- *ServiceEvent) (*Browser, error) {
+	// Implementation in a separate commit/Pull-request
+	return nil, nil
+}
+
+// Entries return the entries in the local cache of the Browser
+func (b *Browser) Entries() []ServiceEntry {
+	// Implementation in a separate commit/Pull-request
+	return nil
+}

--- a/service.go
+++ b/service.go
@@ -107,3 +107,22 @@ func NewServiceEntry(instance, service, domain string) *ServiceEntry {
 		ServiceRecord: *NewServiceRecord(instance, service, domain),
 	}
 }
+
+// ServiceEventType includes the ServiceEntry along with the event that happened in Network
+type ServiceEventType int
+
+const (
+	NewOrUpdated ServiceEventType = iota
+	Removed
+)
+
+// ServiceEvent is returned in channel by browsev3
+type ServiceEvent struct {
+	ServiceEntry
+	EventType ServiceEventType
+}
+
+// Browser is a reference to a specific instance of browser
+type Browser struct {
+	// cache - implemented in a separate commit
+}


### PR DESCRIPTION
Add declarations for ServiceEvent and ServiceEventType which are used by
a new Browser (Browsev3) with TTL expiry and Caching support.

The Implementation and Examples will follow in a separate Commit.

This is first of many patches which implement the functionality of   #10 