### PR TITLE
Fix dropping entries on special dns-sd query (client)

### DIFF
--- a/client.go
+++ b/client.go
@@ -276,10 +276,15 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 				if _, ok := sentEntries[k]; ok {
 					continue
 				}
-				// Require at least one resolved IP address for ServiceEntry
-				// TODO: wait some more time as chances are high both will arrive.
-				if len(e.AddrIPv4) == 0 && len(e.AddrIPv6) == 0 {
-					continue
+
+				// If this is an DNS-SD query do not throw PTR away.
+				// It is expected to have only PTR for enumeration
+				if params.ServiceRecord.ServiceTypeName() != params.ServiceRecord.ServiceName() {
+					// Require at least one resolved IP address for ServiceEntry
+					// TODO: wait some more time as chances are high both will arrive.
+					if len(e.AddrIPv4) == 0 && len(e.AddrIPv6) == 0 {
+						continue
+					}
 				}
 				// Submit entry to subscriber and cache it.
 				// This is also a point to possibly stop probing actively for a


### PR DESCRIPTION
While it may be useful to return only IPs on specific service type, it dropped the ability to enumerate through all services:
> Enumerating Available Service Types - It is possible to enumerate all available services types on a domain by browsing for the special service type "_services._dns-sd._udp".