### PR TITLE
Support for TTL and EventType

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"strings"
 
@@ -83,26 +84,29 @@ func NewResolver(options ...ClientOption) (*Resolver, error) {
 }
 
 // Browse for all services of a given type in a given domain.
-func (r *Resolver) Browse(ctx context.Context, service, domain string, entries chan<- *ServiceEntry) error {
+func (r *Resolver) Browse(ctx context.Context, service, domain string, entries chan<- *ServiceEntry) (*Browser, error) {
+	b := Browser{}
+
 	params := defaultParams(service)
 	if domain != "" {
 		params.Domain = domain
 	}
 	params.Entries = entries
 
-	go r.c.mainloop(ctx, params)
+	b.cache = newEntryCache()
+	go r.c.mainloop(ctx, params, b.cache)
 
 	err := r.c.query(params)
 	if err != nil {
 		_, cancel := context.WithCancel(ctx)
 		cancel()
-		return err
+		return nil, err
 	}
 	// If previous probe was ok, it should be fine now. In case of an error later on,
 	// the entries' queue is closed.
 	go r.c.periodicQuery(ctx, params)
 
-	return nil
+	return &b, nil
 }
 
 // Lookup a specific service by its name and type in a given domain.
@@ -114,7 +118,8 @@ func (r *Resolver) Lookup(ctx context.Context, instance, service, domain string,
 	}
 	params.Entries = entries
 
-	go r.c.mainloop(ctx, params)
+	sentEntries := newEntryCache()
+	go r.c.mainloop(ctx, params, sentEntries)
 
 	err := r.c.query(params)
 	if err != nil {
@@ -174,8 +179,49 @@ func newClient(opts clientOpts) (*client, error) {
 	}, nil
 }
 
+func newEntryCache() *entryCache {
+	return &entryCache{entries: make(map[string]*ServiceEntry)}
+}
+
+func computeExpiryDuration(ec *entryCache) time.Duration {
+	var expDuration time.Duration
+	entries := ec.entries
+	now := time.Now()
+
+	ec.RLock()
+	for _, v := range entries {
+		if v.refreshTime != nil {
+			d := v.refreshTime.Sub(now)
+			if expDuration == 0 {
+				expDuration = d
+			} else if d < expDuration {
+				expDuration = d
+			}
+		}
+		if v.expiryTime != nil {
+			d := v.expiryTime.Sub(now)
+
+			if expDuration == 0 {
+				expDuration = d
+			} else if d < expDuration {
+				expDuration = d
+			}
+		}
+	}
+	ec.RUnlock()
+	//log.Printf("computeExpiryDuration next %d nanoseconds", expDuration)
+	return expDuration
+}
+
 // Start listeners and waits for the shutdown signal from exit channel
-func (c *client) mainloop(ctx context.Context, params *LookupParams) {
+func (c *client) mainloop(ctx context.Context, params *LookupParams, sentEntries *entryCache) {
+	// create a time and stop it. we have a channel in the loop to look for timeouts
+	t := time.NewTimer(time.Second)
+	if !t.Stop() {
+		<-t.C
+	}
+	lastQueriedTime := time.Now()
+
 	// start listening for responses
 	msgCh := make(chan *dns.Msg, 32)
 	if c.ipv4conn != nil {
@@ -186,15 +232,50 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 	}
 
 	// Iterate through channels from listeners goroutines
-	var entries, sentEntries map[string]*ServiceEntry
-	sentEntries = make(map[string]*ServiceEntry)
+	var entries map[string]*ServiceEntry
 	for {
 		select {
 		case <-ctx.Done():
 			// Context expired. Notify subscriber that we are done here.
 			params.done()
 			c.shutdown()
+			if !t.Stop() {
+				<-t.C
+			}
 			return
+		case <-t.C:
+			//log.Printf("timer expired")
+
+			now := time.Now()
+			sentEntries.Lock()
+			for k, v := range sentEntries.entries {
+				if (v.refreshTime != nil) && now.After(*v.refreshTime) {
+					//log.Printf("quering %s because of TTL refresh time expiry", k)
+
+					// query only if my previous query is older than a second
+					// If many entries are getting refreshed in a short time this should prevent flood to the network
+					if lastQueriedTime.Add(1 * time.Second).Before(time.Now()) {
+						c.query(params)
+						lastQueriedTime = time.Now()
+					}
+					v.refreshTime = nil
+				}
+
+				if (v.expiryTime != nil) && now.After(*v.expiryTime) {
+					//log.Printf("deleting %s because of TTL expiry", k)
+					delete(sentEntries.entries, k)
+					if params.Entries != nil {
+						v.eventType = Removed
+						params.Entries <- v
+					}
+				}
+			}
+			sentEntries.Unlock()
+			nextExpiryDuration := computeExpiryDuration(sentEntries)
+			if nextExpiryDuration != 0 {
+				t.Reset(nextExpiryDuration)
+			}
+
 		case msg := <-msgCh:
 			entries = make(map[string]*ServiceEntry)
 			sections := append(msg.Answer, msg.Ns...)
@@ -267,13 +348,29 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 		}
 
 		if len(entries) > 0 {
+			sentEntries.Lock()
 			for k, e := range entries {
 				if e.TTL == 0 {
-					delete(entries, k)
-					delete(sentEntries, k)
+					//log.Printf("Received TTL==0 entry for %s", k)
+					if v, ok := sentEntries.entries[k]; ok {
+						// Expire the entry after 1 second. No need to refresh Entry with a query
+						et := time.Now().Add(1 * time.Second)
+						v.expiryTime = &et
+						v.refreshTime = nil
+					}
 					continue
 				}
-				if _, ok := sentEntries[k]; ok {
+				if v, ok := sentEntries.entries[k]; ok {
+					var rt, et time.Time
+					var frac float64
+
+					// random number between 75-85% of TTL expiry time. convert to float64 to overcome rounding errors
+					frac = (0.75 + rand.Float64()*0.1) * float64(e.TTL) * float64(time.Second)
+					rt = time.Now().Add(time.Duration(frac))
+					v.refreshTime = &rt
+
+					et = time.Now().Add(time.Duration(e.TTL) * time.Second)
+					v.expiryTime = &et
 					continue
 				}
 				// Require at least one resolved IP address for ServiceEntry
@@ -284,9 +381,20 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 				// Submit entry to subscriber and cache it.
 				// This is also a point to possibly stop probing actively for a
 				// service entry.
-				params.Entries <- e
-				sentEntries[k] = e
+				if params.Entries != nil {
+					channelEvent := *e
+					channelEvent.eventType = NewOrUpdated
+					params.Entries <- &channelEvent
+				}
+				sentEntries.entries[k] = e
 				params.disableProbing()
+			}
+			sentEntries.Unlock()
+
+			nextExpiryDuration := computeExpiryDuration(sentEntries)
+			if nextExpiryDuration != 0 {
+				t.Stop()
+				t.Reset(nextExpiryDuration)
 			}
 			// reset entries
 			entries = make(map[string]*ServiceEntry)
@@ -413,8 +521,8 @@ func (c *client) query(params *LookupParams) error {
 	m := new(dns.Msg)
 	if serviceInstanceName != "" {
 		m.Question = []dns.Question{
-			dns.Question{serviceInstanceName, dns.TypeSRV, dns.ClassINET},
-			dns.Question{serviceInstanceName, dns.TypeTXT, dns.ClassINET},
+			dns.Question{Name: serviceInstanceName, Qtype: dns.TypeSRV, Qclass: dns.ClassINET},
+			dns.Question{Name: serviceInstanceName, Qtype: dns.TypeTXT, Qclass: dns.ClassINET},
 		}
 		m.RecursionDesired = false
 	} else {

--- a/examples/resolv/client.go
+++ b/examples/resolv/client.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"time"
 
-	"github.com/grandcat/zeroconf"
+	"github.com/nasuku/zeroconf"
 )
 
 var (
@@ -34,12 +35,14 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*waitTime))
 	defer cancel()
-	err = resolver.Browse(ctx, *service, *domain, entries)
+	b, err := resolver.Browse(ctx, *service, *domain, entries)
 	if err != nil {
 		log.Fatalln("Failed to browse:", err.Error())
 	}
 
 	<-ctx.Done()
+	// can get the total cache anytime
+	fmt.Printf("cached entries: %+v\n", b.Entries())
 	// Wait some additional time to see debug messages on go routine shutdown.
 	time.Sleep(1 * time.Second)
 }

--- a/server.go
+++ b/server.go
@@ -16,6 +16,10 @@ import (
 	"github.com/miekg/dns"
 )
 
+var (
+	DefaultTTL uint32 = 3200
+)
+
 const (
 	// Number of Multicast responses sent for a query message (default: 1 < x < 9)
 	multicastRepitions = 2
@@ -171,7 +175,7 @@ func newServer(ifaces []net.Interface) (*Server, error) {
 		ipv4conn: ipv4conn,
 		ipv6conn: ipv6conn,
 		ifaces:   ifaces,
-		ttl:      3200,
+		ttl:      DefaultTTL,
 	}
 
 	return s, nil


### PR DESCRIPTION
This PR adds Support for TTL. Previously there was no way for an entry to cache out. When a host leaves the network silently others still think that host is present. Now the entry is removed out after the TTL is expired. 

As per the standard, before purging the entry a request is sent to server before the TTL expiry time. This allows the client to refresh the entry if the server is still alive.
To prevent a flood of activity by a whole bunch of clients whose TTL expires at the same time for the same server, the retry time is randomized.

API to return current Cache contents to caller. This way the callers can ask for all the services in the network at any time.

Channel returns both Updated and Deleted entries to the caller. Hence if a node goes away from the network, the callers can know.


@grandcat - This is based on pull-request that I submitted couple of months back. I cleaned up to make the change set much small. Please take a look and let me know your thoughts.