### PR TITLE
Add TTL options to Register and RegisterProxy, and keep IPs given for RegisterProxy

### DIFF
--- a/server.go
+++ b/server.go
@@ -23,7 +23,7 @@ const (
 
 // Register a service by given arguments. This call will take the system's hostname
 // and lookup IP by that hostname.
-func Register(instance, service, domain string, port int, text []string, ifaces []net.Interface) (*Server, error) {
+func Register(instance, service, domain string, port int, text []string, ifaces []net.Interface, ttl uint32) (*Server, error) {
 	entry := NewServiceEntry(instance, service, domain)
 	entry.Port = port
 	entry.Text = text
@@ -72,6 +72,8 @@ func Register(instance, service, domain string, port int, text []string, ifaces 
 		return nil, err
 	}
 
+	s.TTL(ttl)
+
 	s.service = entry
 	go s.mainloop()
 	go s.probe()
@@ -81,7 +83,7 @@ func Register(instance, service, domain string, port int, text []string, ifaces 
 
 // RegisterProxy registers a service proxy. This call will skip the hostname/IP lookup and
 // will use the provided values.
-func RegisterProxy(instance, service, domain string, port int, host string, ips []string, text []string, ifaces []net.Interface) (*Server, error) {
+func RegisterProxy(instance, service, domain string, port int, host string, ips []string, text []string, ifaces []net.Interface, ttl uint32) (*Server, error) {
 	entry := NewServiceEntry(instance, service, domain)
 	entry.Port = port
 	entry.Text = text
@@ -128,6 +130,8 @@ func RegisterProxy(instance, service, domain string, port int, host string, ips 
 	if err != nil {
 		return nil, err
 	}
+
+	s.TTL(ttl)
 
 	s.service = entry
 	go s.mainloop()


### PR DESCRIPTION
The TTL config was set on the Server, but not exposed via the Register and RegisterProxy calls. Also, appendAddrs() would *always* get IPs from the interfaces in use, even if RegisterProxy wanted to keep them the same. Added a "refresh_ips" option on Server, and a check in appendAddrs() so that RegisterProxy gets the behavior it expects.