### PR TITLE
Default server domain to `local.`

### DIFF
--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ func Register(instance, service, domain string, port int, text []string, ifaces 
 		return nil, fmt.Errorf("Missing service name")
 	}
 	if entry.Domain == "" {
-		entry.Domain = "local"
+		entry.Domain = "local."
 	}
 	if entry.Port == 0 {
 		return nil, fmt.Errorf("Missing port")


### PR DESCRIPTION
Previously server were defaulting to `local` which caused error: 
```
2017/08/20 12:13:10 [ERR] zeroconf: failed to send probe: dns: bad rdata
2017/08/20 12:13:11 [ERR] zeroconf: failed to send probe: dns: bad rdata
2017/08/20 12:13:11 [ERR] zeroconf: failed to send announcement: dns: bad rdata
2017/08/20 12:13:12 [ERR] zeroconf: failed to send announcement: dns: bad rdata
```
The domain should contain dot at the end. Updated server to default properly to `local.` value.

Fixes #28 