### PR TITLE
Fix appendAddrs behavior for proxy services

### DIFF
--- a/server.go
+++ b/server.go
@@ -600,13 +600,15 @@ func (s *Server) unregister() error {
 }
 
 func (s *Server) appendAddrs(list []dns.RR, ttl uint32, ifIndex int, flushCache bool) []dns.RR {
-	var v4, v6 []net.IP
-	iface, _ := net.InterfaceByIndex(ifIndex)
-	if iface != nil {
-		v4, v6 = addrsForInterface(iface)
-	} else {
-		v4 = s.service.AddrIPv4
-		v6 = s.service.AddrIPv6
+	v4 := s.service.AddrIPv4
+	v6 := s.service.AddrIPv6
+	if len(v4) == 0 && len(v6) == 0 {
+		iface, _ := net.InterfaceByIndex(ifIndex)
+		if iface != nil {
+			a4, a6 := addrsForInterface(iface)
+			v4 = append(v4, a4...)
+			v6 = append(v6, a6...)
+		}
 	}
 	if ttl > 0 {
 		// RFC6762 Section 10 says A/AAAA records SHOULD


### PR DESCRIPTION
This commit fixes the behaviour of `appendAddrs` so that IP addresses provided to `RegisterProxy` will actually be used in the service advertisement.

Before this PR, interface addresses were being used if available and the provided IP addresses to `RegisterProxy` were being ignored as a result. It was therefore impossible to advertise services on behalf of another host - the services would always advertise the current node's IP addresses instead.

This PR instead prefers the IP addresses in `s.service.AddrIPv4` and `s.service.AddrIPv6` instead, and only defaults to using interface addresses if those are not specified. This effectively fixes `RegisterProxy`. 