### PR TITLE
Add support for subtypes

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,6 +218,7 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 						entries[rr.Ptr] = NewServiceEntry(
 							trimDot(strings.Replace(rr.Ptr, rr.Hdr.Name, "", -1)),
 							params.Service,
+							params.Subtypes,
 							params.Domain)
 					}
 					entries[rr.Ptr].TTL = rr.Hdr.Ttl
@@ -231,6 +232,7 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 						entries[rr.Hdr.Name] = NewServiceEntry(
 							trimDot(strings.Replace(rr.Hdr.Name, params.ServiceName(), "", 1)),
 							params.Service,
+							params.Subtypes,
 							params.Domain)
 					}
 					entries[rr.Hdr.Name].HostName = rr.Target
@@ -246,6 +248,7 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 						entries[rr.Hdr.Name] = NewServiceEntry(
 							trimDot(strings.Replace(rr.Hdr.Name, params.ServiceName(), "", 1)),
 							params.Service,
+							params.Subtypes,
 							params.Domain)
 					}
 					entries[rr.Hdr.Name].Text = rr.Txt
@@ -411,6 +414,10 @@ func (c *client) periodicQuery(ctx context.Context, params *LookupParams) error 
 func (c *client) query(params *LookupParams) error {
 	var serviceName, serviceInstanceName string
 	serviceName = fmt.Sprintf("%s.%s.", trimDot(params.Service), trimDot(params.Domain))
+	if len(params.Subtypes) > 0 {
+		serviceName = fmt.Sprintf("%s._sub.%s", params.Subtypes[0], serviceName)
+	}
+
 	if params.Instance != "" {
 		serviceInstanceName = fmt.Sprintf("%s.%s", params.Instance, serviceName)
 	}

--- a/service.go
+++ b/service.go
@@ -8,9 +8,10 @@ import (
 
 // ServiceRecord contains the basic description of a service, which contains instance name, service type & domain
 type ServiceRecord struct {
-	Instance string `json:"name"`   // Instance name (e.g. "My web page")
-	Service  string `json:"type"`   // Service name (e.g. _http._tcp.)
-	Domain   string `json:"domain"` // If blank, assumes "local"
+	Instance string   `json:"name"`     // Instance name (e.g. "My web page")
+	Service  string   `json:"type"`     // Service name (e.g. _http._tcp.)
+	Subtypes []string `json:"subtypes"` // Service subtypes
+	Domain   string   `json:"domain"`   // If blank, assumes "local"
 
 	// private variable populated on ServiceRecord creation
 	serviceName         string
@@ -36,10 +37,11 @@ func (s *ServiceRecord) ServiceTypeName() string {
 }
 
 // NewServiceRecord constructs a ServiceRecord.
-func NewServiceRecord(instance, service, domain string) *ServiceRecord {
+func NewServiceRecord(instance, service string, subtypes []string, domain string) *ServiceRecord {
 	s := &ServiceRecord{
 		Instance:    instance,
 		Service:     service,
+		Subtypes:    subtypes,
 		Domain:      domain,
 		serviceName: fmt.Sprintf("%s.%s.", trimDot(service), trimDot(domain)),
 	}
@@ -70,8 +72,9 @@ type LookupParams struct {
 
 // NewLookupParams constructs a LookupParams.
 func NewLookupParams(instance, service, domain string, entries chan<- *ServiceEntry) *LookupParams {
+	service, subtypes := parseSubtypes(service)
 	return &LookupParams{
-		ServiceRecord: *NewServiceRecord(instance, service, domain),
+		ServiceRecord: *NewServiceRecord(instance, service, subtypes, domain),
 		Entries:       entries,
 
 		stopProbing: make(chan struct{}),
@@ -102,8 +105,8 @@ type ServiceEntry struct {
 }
 
 // NewServiceEntry constructs a ServiceEntry.
-func NewServiceEntry(instance, service, domain string) *ServiceEntry {
+func NewServiceEntry(instance, service string, subtypes []string, domain string) *ServiceEntry {
 	return &ServiceEntry{
-		ServiceRecord: *NewServiceRecord(instance, service, domain),
+		ServiceRecord: *NewServiceRecord(instance, service, subtypes, domain),
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,11 @@ package zeroconf
 
 import "strings"
 
+func parseSubtypes(service string) (string, []string) {
+	subtypes := strings.Split(service, ",")
+	return subtypes[0], subtypes[1:]
+}
+
 // trimDot is used to trim the dots from the start or end of a string
 func trimDot(s string) string {
 	return strings.Trim(s, ".")


### PR DESCRIPTION
Feature to address #36 

This adds the ability to query services by subtype as well as register one or more subtypes for a service.

Subtypes are specified as a comma delimited list following the service type. eg: _ipp._tcp,_universal

When browsing you can specify at most one subtype (further subtypes are ignored), but when you register a service it will add a PTR record for each subtype given in the list.