### PR TITLE
Added simple change to allow user detection of services *leaving* via…

### DIFF
--- a/examples/resolv/client.go
+++ b/examples/resolv/client.go
@@ -27,7 +27,11 @@ func main() {
 	entries := make(chan *zeroconf.ServiceEntry)
 	go func(results <-chan *zeroconf.ServiceEntry) {
 		for entry := range results {
-			log.Println(entry)
+			if entry.TTL>0 {
+				log.Println("[+]", entry)
+			} else {
+				log.Println("[-]", entry)
+			}
 		}
 		log.Println("No more entries.")
 	}(entries)


### PR DESCRIPTION
… TTL=0 in DNS-SD messages.

This is quite useful to detect when services gracefully leave zeroconf, which is handy when implementing various approaches to dynamic networking.

I've also modified the `resolv` example to prepend "[+]" or "[-]" to the service information; this indicates whether a) the service was detected, or b) it just (gracefully) left.