### PR TITLE
Finish server shutdown after unregister error

### DIFF
--- a/server.go
+++ b/server.go
@@ -217,9 +217,6 @@ func (s *Server) shutdown() error {
 	}
 
 	err := s.unregister()
-	if err != nil {
-		return err
-	}
 
 	close(s.shouldShutdown)
 
@@ -234,7 +231,7 @@ func (s *Server) shutdown() error {
 	s.shutdownEnd.Wait()
 	s.isShutdown = true
 
-	return nil
+	return err
 }
 
 // recv is a long running routine to receive packets from an interface


### PR DESCRIPTION
Previously if s.unregister returns an error, the server shutdown
will prematurely end. This will strand goroutines and lead to
memory leaks.