### PR TITLE
Add support for subtype (with fixes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ go:
   - "1.13"
 
 script:
-  - go test
+  - go test --parallel=1

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ if err != nil {
 
 <-ctx.Done()
 ```
+A subtype may added to service name to narrow the set of results. E.g. to browse `_workstation._tcp` with subtype `_windows`, use`_workstation._tcp,_windows`.
+
 See https://github.com/grandcat/zeroconf/blob/master/examples/resolv/client.go.
 
 ## Lookup a specific service instance
@@ -81,6 +83,8 @@ case <-time.After(time.Second * 120):
 
 log.Println("Shutting down.")
 ```
+Multiple subtypes may be added to service name, separated by commas. E.g `_workstation._tcp,_windows` has subtype `_windows`.
+
 See https://github.com/grandcat/zeroconf/blob/master/examples/register/server.go.
 
 ## Features and ToDo's

--- a/client.go
+++ b/client.go
@@ -217,6 +217,7 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 						entries[rr.Ptr] = NewServiceEntry(
 							trimDot(strings.Replace(rr.Ptr, rr.Hdr.Name, "", -1)),
 							params.Service,
+							params.Subtypes,
 							params.Domain)
 					}
 					entries[rr.Ptr].TTL = rr.Hdr.Ttl
@@ -230,6 +231,7 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 						entries[rr.Hdr.Name] = NewServiceEntry(
 							trimDot(strings.Replace(rr.Hdr.Name, params.ServiceName(), "", 1)),
 							params.Service,
+							params.Subtypes,
 							params.Domain)
 					}
 					entries[rr.Hdr.Name].HostName = rr.Target
@@ -245,6 +247,7 @@ func (c *client) mainloop(ctx context.Context, params *LookupParams) {
 						entries[rr.Hdr.Name] = NewServiceEntry(
 							trimDot(strings.Replace(rr.Hdr.Name, params.ServiceName(), "", 1)),
 							params.Service,
+							params.Subtypes,
 							params.Domain)
 					}
 					entries[rr.Hdr.Name].Text = rr.Txt
@@ -409,6 +412,10 @@ func (c *client) periodicQuery(ctx context.Context, params *LookupParams) error 
 func (c *client) query(params *LookupParams) error {
 	var serviceName, serviceInstanceName string
 	serviceName = fmt.Sprintf("%s.%s.", trimDot(params.Service), trimDot(params.Domain))
+	if len(params.Subtypes) > 0 {
+		serviceName = fmt.Sprintf("%s._sub.%s", params.Subtypes[0], serviceName)
+	}
+
 	if params.Instance != "" {
 		serviceInstanceName = fmt.Sprintf("%s.%s", params.Instance, serviceName)
 	}

--- a/service.go
+++ b/service.go
@@ -37,13 +37,17 @@ func (s *ServiceRecord) ServiceTypeName() string {
 }
 
 // NewServiceRecord constructs a ServiceRecord.
-func NewServiceRecord(instance, service string, subtypes []string, domain string) *ServiceRecord {
+func NewServiceRecord(instance, service string, domain string) *ServiceRecord {
+	service, subtypes := parseSubtypes(service)
 	s := &ServiceRecord{
 		Instance:    instance,
 		Service:     service,
-		Subtypes:    subtypes,
 		Domain:      domain,
 		serviceName: fmt.Sprintf("%s.%s.", trimDot(service), trimDot(domain)),
+	}
+
+	for _, subtype := range subtypes {
+		s.Subtypes = append(s.Subtypes, fmt.Sprintf("%s._sub.%s", trimDot(subtype), s.serviceName))
 	}
 
 	// Cache service instance name
@@ -72,9 +76,8 @@ type LookupParams struct {
 
 // NewLookupParams constructs a LookupParams.
 func NewLookupParams(instance, service, domain string, entries chan<- *ServiceEntry) *LookupParams {
-	service, subtypes := parseSubtypes(service)
 	return &LookupParams{
-		ServiceRecord: *NewServiceRecord(instance, service, subtypes, domain),
+		ServiceRecord: *NewServiceRecord(instance, service, domain),
 		Entries:       entries,
 
 		stopProbing: make(chan struct{}),
@@ -105,8 +108,8 @@ type ServiceEntry struct {
 }
 
 // NewServiceEntry constructs a ServiceEntry.
-func NewServiceEntry(instance, service string, subtypes []string, domain string) *ServiceEntry {
+func NewServiceEntry(instance, service string, domain string) *ServiceEntry {
 	return &ServiceEntry{
-		ServiceRecord: *NewServiceRecord(instance, service, subtypes, domain),
+		ServiceRecord: *NewServiceRecord(instance, service, domain),
 	}
 }

--- a/service.go
+++ b/service.go
@@ -8,9 +8,10 @@ import (
 
 // ServiceRecord contains the basic description of a service, which contains instance name, service type & domain
 type ServiceRecord struct {
-	Instance string `json:"name"`   // Instance name (e.g. "My web page")
-	Service  string `json:"type"`   // Service name (e.g. _http._tcp.)
-	Domain   string `json:"domain"` // If blank, assumes "local"
+	Instance string   `json:"name"`     // Instance name (e.g. "My web page")
+	Service  string   `json:"type"`     // Service name (e.g. _http._tcp.)
+	Subtypes []string `json:"subtypes"` // Service subtypes
+	Domain   string   `json:"domain"`   // If blank, assumes "local"
 
 	// private variable populated on ServiceRecord creation
 	serviceName         string
@@ -36,10 +37,11 @@ func (s *ServiceRecord) ServiceTypeName() string {
 }
 
 // NewServiceRecord constructs a ServiceRecord.
-func NewServiceRecord(instance, service, domain string) *ServiceRecord {
+func NewServiceRecord(instance, service string, subtypes []string, domain string) *ServiceRecord {
 	s := &ServiceRecord{
 		Instance:    instance,
 		Service:     service,
+		Subtypes:    subtypes,
 		Domain:      domain,
 		serviceName: fmt.Sprintf("%s.%s.", trimDot(service), trimDot(domain)),
 	}
@@ -70,8 +72,9 @@ type LookupParams struct {
 
 // NewLookupParams constructs a LookupParams.
 func NewLookupParams(instance, service, domain string, entries chan<- *ServiceEntry) *LookupParams {
+	service, subtypes := parseSubtypes(service)
 	return &LookupParams{
-		ServiceRecord: *NewServiceRecord(instance, service, domain),
+		ServiceRecord: *NewServiceRecord(instance, service, subtypes, domain),
 		Entries:       entries,
 
 		stopProbing: make(chan struct{}),
@@ -102,8 +105,8 @@ type ServiceEntry struct {
 }
 
 // NewServiceEntry constructs a ServiceEntry.
-func NewServiceEntry(instance, service, domain string) *ServiceEntry {
+func NewServiceEntry(instance, service string, subtypes []string, domain string) *ServiceEntry {
 	return &ServiceEntry{
-		ServiceRecord: *NewServiceRecord(instance, service, domain),
+		ServiceRecord: *NewServiceRecord(instance, service, subtypes, domain),
 	}
 }

--- a/service_test.go
+++ b/service_test.go
@@ -11,7 +11,8 @@ import (
 
 var (
 	mdnsName    = "test--xxxxxxxxxxxx"
-	mdnsService = "test--xxxx.tcp"
+	mdnsService = "_test--xxxx._tcp"
+	mdnsSubtype = "_test--xxxx._tcp,_fancy"
 	mdnsDomain  = "local."
 	mdnsPort    = 8888
 )
@@ -93,4 +94,88 @@ func TestNoRegister(t *testing.T) {
 	}
 	<-ctx.Done()
 	cancel()
+}
+
+func TestSubtype(t *testing.T) {
+	t.Run("browse with subtype", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go startMDNS(ctx, mdnsPort, mdnsName, mdnsSubtype, mdnsDomain)
+
+		time.Sleep(time.Second)
+
+		resolver, err := NewResolver(nil)
+		if err != nil {
+			t.Fatalf("Expected create resolver success, but got %v", err)
+		}
+		entries := make(chan *ServiceEntry)
+		var expectedResult []*ServiceEntry
+		go func(results <-chan *ServiceEntry) {
+			s := <-results
+			expectedResult = append(expectedResult, s)
+		}(entries)
+
+		if err := resolver.Browse(ctx, mdnsSubtype, mdnsDomain, entries); err != nil {
+			t.Fatalf("Expected browse success, but got %v", err)
+		}
+		<-ctx.Done()
+
+		if len(expectedResult) != 1 {
+			t.Fatalf("Expected number of service entries is 1, but got %d", len(expectedResult))
+		}
+		if expectedResult[0].Domain != mdnsDomain {
+			t.Fatalf("Expected domain is %s, but got %s", mdnsDomain, expectedResult[0].Domain)
+		}
+		if expectedResult[0].Service != mdnsService {
+			t.Fatalf("Expected service is %s, but got %s", mdnsService, expectedResult[0].Service)
+		}
+		if expectedResult[0].Instance != mdnsName {
+			t.Fatalf("Expected instance is %s, but got %s", mdnsName, expectedResult[0].Instance)
+		}
+		if expectedResult[0].Port != mdnsPort {
+			t.Fatalf("Expected port is %d, but got %d", mdnsPort, expectedResult[0].Port)
+		}
+	})
+
+	t.Run("browse without subtype", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go startMDNS(ctx, mdnsPort, mdnsName, mdnsSubtype, mdnsDomain)
+
+		time.Sleep(time.Second)
+
+		resolver, err := NewResolver(nil)
+		if err != nil {
+			t.Fatalf("Expected create resolver success, but got %v", err)
+		}
+		entries := make(chan *ServiceEntry)
+		var expectedResult []*ServiceEntry
+		go func(results <-chan *ServiceEntry) {
+			s := <-results
+			expectedResult = append(expectedResult, s)
+		}(entries)
+
+		if err := resolver.Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
+			t.Fatalf("Expected browse success, but got %v", err)
+		}
+		<-ctx.Done()
+
+		if len(expectedResult) != 1 {
+			t.Fatalf("Expected number of service entries is 1, but got %d", len(expectedResult))
+		}
+		if expectedResult[0].Domain != mdnsDomain {
+			t.Fatalf("Expected domain is %s, but got %s", mdnsDomain, expectedResult[0].Domain)
+		}
+		if expectedResult[0].Service != mdnsService {
+			t.Fatalf("Expected service is %s, but got %s", mdnsService, expectedResult[0].Service)
+		}
+		if expectedResult[0].Instance != mdnsName {
+			t.Fatalf("Expected instance is %s, but got %s", mdnsName, expectedResult[0].Instance)
+		}
+		if expectedResult[0].Port != mdnsPort {
+			t.Fatalf("Expected port is %d, but got %d", mdnsPort, expectedResult[0].Port)
+		}
+	})
 }

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,11 @@ package zeroconf
 
 import "strings"
 
+func parseSubtypes(service string) (string, []string) {
+	subtypes := strings.Split(service, ",")
+	return subtypes[0], subtypes[1:]
+}
+
 // trimDot is used to trim the dots from the start or end of a string
 func trimDot(s string) string {
 	return strings.Trim(s, ".")


### PR DESCRIPTION
This is written on top of https://github.com/grandcat/zeroconf/pull/49
Closes https://github.com/grandcat/zeroconf/issues/36

In comparison, it:
- Adds subtype PTR records to registration
- Adds the support without changing the API (i.e. exported functions)
- Fixes a bug in query, which breaks lookup when subtype is set
- Adds some tests

I've also tested it against avahi and dns-sd tools:

Registration with the package:
```
> go run examples/register/server.go --service="_workstation._tcp,_windows" --name="Windows Workstation"
2020/05/22 16:00:05 Published service:
2020/05/22 16:00:05 - Name: Windows Workstation
2020/05/22 16:00:05 - Type: _workstation._tcp,_windows
2020/05/22 16:00:05 - Domain: local.
2020/05/22 16:00:05 - Port: 42424
```
Discovery (macOS dns-sd):
```
> dns-sd -B _workstation._tcp,_windows
Browsing for _workstation._tcp,_windows
DATE: ---Fri 22 May 2020---
16:00:00.013  ...STARTING...
Timestamp     A/R    Flags  if Domain               Service Type         Instance Name
16:00:05.566  Add        3   1 local.               _workstation._tcp.   Windows Workstation
16:00:05.566  Add        2   5 local.               _workstation._tcp.   Windows Workstation
```
Similar results on browse without subtype: `dns-sd -B _workstation._tcp`

Discovery (debian avahi-browser):
```
> avahi-browse _windows._sub._workstation._tcp
+   eth0 IPv4 Windows Workstation                           Workstation          local
+   eth0 IPv6 Windows Workstation                           Workstation          local
```
Similar results on browse without subtype: `avahi-browse _workstation._tcp`

---
Registration with dns-sd client on macOS:
```
> dns-sd -R "Mac Workstation" _workstation._tcp,_macos local 1003
Registering Service Mac Workstation._workstation._tcp,_macos.local port 1003
DATE: ---Fri 22 May 2020---
16:03:01.020  ...STARTING...
16:03:01.735  Got a reply for service Mac Workstation._workstation._tcp.local.: Name now registered and active
```
Another registration with avahi-publish on debian:
```
> avahi-publish -s "Linux Workstation" "_workstation._tcp" --subtype="_linux._sub._workstation._tcp" 1004
Established under name 'Linux Workstation'
```

Browse with this package (workstation of type _linux):
```
> go run examples/resolv/client.go --service="_workstation._tcp,_linux"
2020/05/22 16:03:53 &{{Linux\ Workstation _workstation._tcp [] local _workstation._tcp.local. Linux\ Workstation._workstation._tcp.local. _services._dns-sd._udp.local.} ...
2020/05/22 16:04:02 No more entries.
```

Browser without subtype (workstations of all types):
```
> go run examples/resolv/client.go --service="_workstation._tcp"
2020/05/22 16:04:23 &{{Linux\ Workstation _workstation._tcp [] local _workstation._tcp.local. Linux\ Workstation._workstation._tcp.local. _services._dns-sd._udp.local.} ...
2020/05/22 16:04:23 &{{Mac\ Workstation _workstation._tcp [] local _workstation._tcp.local. Mac\ Workstation._workstation._tcp.local. _services._dns-sd._udp.local.} ...
2020/05/22 16:04:31 No more entries.
```