### PR TITLE
add SelectFilter option to support custom filters

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,13 +26,23 @@ const (
 	IPv4AndIPv6 = (IPv4 | IPv6) //< Default option.
 )
 
+type FilterFunc func(net.Interface) bool
+
 type clientOpts struct {
 	listenOn IPType
 	ifaces   []net.Interface
+	filter   FilterFunc
 }
 
 // ClientOption fills the option struct to configure intefaces, etc.
 type ClientOption func(*clientOpts)
+
+// SelectFilter
+func SelectFilter(filter FilterFunc) ClientOption {
+	return func(o *clientOpts) {
+		o.filter = filter
+	}
+}
 
 // SelectIPTraffic selects the type of IP packets (IPv4, IPv6, or both) this
 // instance listens for.
@@ -154,7 +164,7 @@ func newClient(opts clientOpts) (*client, error) {
 	var ipv4conn *ipv4.PacketConn
 	if (opts.listenOn & IPv4) > 0 {
 		var err error
-		ipv4conn, err = joinUdp4Multicast(ifaces)
+		ipv4conn, err = joinUdp4Multicast(ifaces, opts.filter)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +173,7 @@ func newClient(opts clientOpts) (*client, error) {
 	var ipv6conn *ipv6.PacketConn
 	if (opts.listenOn & IPv6) > 0 {
 		var err error
-		ipv6conn, err = joinUdp6Multicast(ifaces)
+		ipv6conn, err = joinUdp6Multicast(ifaces, opts.filter)
 		if err != nil {
 			return nil, err
 		}

--- a/connection.go
+++ b/connection.go
@@ -35,7 +35,7 @@ var (
 	}
 )
 
-func joinUdp6Multicast(interfaces []net.Interface) (*ipv6.PacketConn, error) {
+func joinUdp6Multicast(interfaces []net.Interface, filter FilterFunc) (*ipv6.PacketConn, error) {
 	udpConn, err := net.ListenUDP("udp6", mdnsWildcardAddrIPv6)
 	if err != nil {
 		return nil, err
@@ -52,6 +52,13 @@ func joinUdp6Multicast(interfaces []net.Interface) (*ipv6.PacketConn, error) {
 
 	var failedJoins int
 	for _, iface := range interfaces {
+		if filter != nil {
+			if !filter(iface) {
+				failedJoins++
+				continue
+			}
+		}
+
 		if err := pkConn.JoinGroup(&iface, &net.UDPAddr{IP: mdnsGroupIPv6}); err != nil {
 			// log.Println("Udp6 JoinGroup failed for iface ", iface)
 			failedJoins++
@@ -65,7 +72,7 @@ func joinUdp6Multicast(interfaces []net.Interface) (*ipv6.PacketConn, error) {
 	return pkConn, nil
 }
 
-func joinUdp4Multicast(interfaces []net.Interface) (*ipv4.PacketConn, error) {
+func joinUdp4Multicast(interfaces []net.Interface, filter FilterFunc) (*ipv4.PacketConn, error) {
 	udpConn, err := net.ListenUDP("udp4", mdnsWildcardAddrIPv4)
 	if err != nil {
 		// log.Printf("[ERR] bonjour: Failed to bind to udp4 mutlicast: %v", err)
@@ -83,6 +90,13 @@ func joinUdp4Multicast(interfaces []net.Interface) (*ipv4.PacketConn, error) {
 
 	var failedJoins int
 	for _, iface := range interfaces {
+		if filter != nil {
+			if !filter(iface) {
+				failedJoins++
+				continue
+			}
+		}
+
 		if err := pkConn.JoinGroup(&iface, &net.UDPAddr{IP: mdnsGroupIPv4}); err != nil {
 			// log.Println("Udp4 JoinGroup failed for iface ", iface)
 			failedJoins++

--- a/server.go
+++ b/server.go
@@ -156,11 +156,11 @@ type Server struct {
 
 // Constructs server structure
 func newServer(ifaces []net.Interface) (*Server, error) {
-	ipv4conn, err4 := joinUdp4Multicast(ifaces)
+	ipv4conn, err4 := joinUdp4Multicast(ifaces, nil)
 	if err4 != nil {
 		log.Printf("[zeroconf] no suitable IPv4 interface: %s", err4.Error())
 	}
-	ipv6conn, err6 := joinUdp6Multicast(ifaces)
+	ipv6conn, err6 := joinUdp6Multicast(ifaces, nil)
 	if err6 != nil {
 		log.Printf("[zeroconf] no suitable IPv6 interface: %s", err6.Error())
 	}


### PR DESCRIPTION
It is difficult to bind a specific interface on Win7 since the implement of SetControlMessage is blank. So custom filters is the most simple way for me to solve this problem. And I think it is also useful for other situations.