### PR TITLE
Fix client multicast sending on Windows

### DIFF
--- a/client.go
+++ b/client.go
@@ -443,17 +443,21 @@ func (c *client) sendQuery(msg *dns.Msg) error {
 		return err
 	}
 	if c.ipv4conn != nil {
-		var wcm ipv4.ControlMessage
 		for ifi := range c.ifaces {
-			wcm.IfIndex = c.ifaces[ifi].Index
-			c.ipv4conn.WriteTo(buf, &wcm, ipv4Addr)
+			if err := c.ipv4conn.SetMulticastInterface(&c.ifaces[ifi]); err != nil {
+				// log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
+				continue
+			}
+			c.ipv4conn.WriteTo(buf, nil, ipv4Addr)
 		}
 	}
 	if c.ipv6conn != nil {
-		var wcm ipv6.ControlMessage
 		for ifi := range c.ifaces {
-			wcm.IfIndex = c.ifaces[ifi].Index
-			c.ipv6conn.WriteTo(buf, &wcm, ipv6Addr)
+			if err := c.ipv6conn.SetMulticastInterface(&c.ifaces[ifi]); err != nil {
+				// log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
+				continue
+			}
+			c.ipv6conn.WriteTo(buf, nil, ipv6Addr)
 		}
 	}
 	return nil


### PR DESCRIPTION
I'm attempting to use go-chromecast on Windows which leverages this library. Unfortunately mDNS wasn't working. I was able to fix it by replacing the code that used `ControlMessage` in `WriteTo()` with a call to `SetMulticastInterface()` instead. I think this may be related to issues #54 #69 and #75. I've tested this change on Windows and Linux and I will test on macOS shortly as well. I only changed client.go but it's possible a similar change is needed in server.go as well.

In the [docs for the ipv4 package](https://pkg.go.dev/golang.org/x/net/ipv4#pkg-note-BUG) under Bugs there is this note:
> On Windows, the ControlMessage for ReadFrom and WriteTo methods of PacketConn is not implemented.

Additionally, the [ipv4 docs on Multicasting here](https://pkg.go.dev/golang.org/x/net/ipv4#hdr-Multicasting) show an example using SetMulticastInterface() as I've done in this PR which suggests to me that this is an OK way to handle this issue, but if you'd prefer something else I'd be happy to change it.

Thanks for making zeroconf and for considering this PR.