### PR TITLE
Resolve local names

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See what needs to be done and submit a pull request :)
 * [x] Browse / Lookup / Register services
 * [x] Multiple IPv6 / IPv4 addresses support
 * [x] Send multiple probes (exp. back-off) if no service answers (*)
+* [x] Resolve mdns host names
 * [ ] Timestamp entries for TTL checks
 * [ ] Compare new multicasts with already received services
 

--- a/service.go
+++ b/service.go
@@ -72,6 +72,7 @@ type LookupParams struct {
 
 	stopProbing chan struct{}
 	once        sync.Once
+	queryType   uint16 // set in client.Resolve() for host lookup
 }
 
 // NewLookupParams constructs a LookupParams.


### PR DESCRIPTION
Fixes #83 

Adds support for `Client.Resolve()` and `Client.ResolveOnce()` to allow local mdns hostname resolutions without querying for a particular service.