### PR TITLE
don't stop querying when browsing

### DIFF
--- a/service.go
+++ b/service.go
@@ -70,18 +70,22 @@ type lookupParams struct {
 	ServiceRecord
 	Entries chan<- *ServiceEntry // Entries Channel
 
+	isBrowsing  bool
 	stopProbing chan struct{}
 	once        sync.Once
 }
 
 // newLookupParams constructs a lookupParams.
-func newLookupParams(instance, service, domain string, entries chan<- *ServiceEntry) *lookupParams {
-	return &lookupParams{
+func newLookupParams(instance, service, domain string, isBrowsing bool, entries chan<- *ServiceEntry) *lookupParams {
+	p := &lookupParams{
 		ServiceRecord: *NewServiceRecord(instance, service, domain),
 		Entries:       entries,
-
-		stopProbing: make(chan struct{}),
+		isBrowsing:    isBrowsing,
 	}
+	if !isBrowsing {
+		p.stopProbing = make(chan struct{})
+	}
+	return p
 }
 
 // Notify subscriber that no more entries will arrive. Mostly caused

--- a/service_test.go
+++ b/service_test.go
@@ -152,10 +152,16 @@ func TestSubtype(t *testing.T) {
 		}
 		entries := make(chan *ServiceEntry)
 		var expectedResult []*ServiceEntry
-		go func(results <-chan *ServiceEntry) {
-			s := <-results
-			expectedResult = append(expectedResult, s)
-		}(entries)
+		go func() {
+			for {
+				select {
+				case s := <-entries:
+					expectedResult = append(expectedResult, s)
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
 
 		if err := resolver.Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
 			t.Fatalf("Expected browse success, but got %v", err)


### PR DESCRIPTION
I'm assuming that `Browse` is supposed to implement Continuous Querying as described in [section 5.2, RFC 6762](https://datatracker.ietf.org/doc/html/rfc6762#section-5.2). We shouldn't stop querying after receiving the first result, as new devices might have joined the network after `Browse` was started.

Note that since we
1. implement exponential backoff and
2. Known-Answer Suppression according to section 7.1

continuously querying won't lead to excessive load on the network.

This PR builds on top of #91. Splitting it out, since technically it's a change of the public API.