### PR TITLE
rework the client-side API, remove the Resolver, make Browse and Lookup package-level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ This package requires **Go 1.7** (context in std lib) or later.
 ## Browse for services in your local network
 
 ```go
-// Discover all services on the network (e.g. _workstation._tcp)
-resolver, err := zeroconf.NewResolver(nil)
-if err != nil {
-    log.Fatalln("Failed to initialize resolver:", err.Error())
-}
-
 entries := make(chan *zeroconf.ServiceEntry)
 go func(results <-chan *zeroconf.ServiceEntry) {
     for entry := range results {
@@ -45,6 +39,7 @@ go func(results <-chan *zeroconf.ServiceEntry) {
 
 ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 defer cancel()
+// Discover all services on the network (e.g. _workstation._tcp)
 err = resolver.Browse(ctx, "_workstation._tcp", "local.", entries)
 if err != nil {
     log.Fatalln("Failed to browse:", err.Error())

--- a/client.go
+++ b/client.go
@@ -104,21 +104,12 @@ func applyOpts(options ...ClientOption) clientOpts {
 
 func (c *client) run(ctx context.Context, params *lookupParams) error {
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go c.mainloop(ctx, params)
 
-	if err := c.query(params); err != nil {
-		cancel()
-		return err
-	}
 	// If previous probe was ok, it should be fine now. In case of an error later on,
 	// the entries' queue is closed.
-	go func() {
-		if err := c.periodicQuery(ctx, params); err != nil {
-			cancel()
-		}
-	}()
-
-	return nil
+	return c.periodicQuery(ctx, params)
 }
 
 // defaultParams returns a default set of QueryParams.
@@ -362,6 +353,10 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 		}
 	}()
 	for {
+		// Do periodic query.
+		if err := c.query(params); err != nil {
+			return err
+		}
 		// Backoff and cancel logic.
 		wait := bo.NextBackOff()
 		if wait == backoff.Stop {
@@ -372,6 +367,7 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 		} else {
 			timer.Reset(wait)
 		}
+
 		select {
 		case <-timer.C:
 			// Wait for next iteration.
@@ -380,11 +376,10 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 			// Done here. Received a matching mDNS entry.
 			return nil
 		case <-ctx.Done():
+			if params.isBrowsing {
+				return nil
+			}
 			return ctx.Err()
-		}
-		// Do periodic query.
-		if err := c.query(params); err != nil {
-			return err
 		}
 	}
 }
@@ -409,11 +404,7 @@ func (c *client) query(params *lookupParams) error {
 		m.SetQuestion(serviceName, dns.TypePTR)
 	}
 	m.RecursionDesired = false
-	if err := c.sendQuery(m); err != nil {
-		return err
-	}
-
-	return nil
+	return c.sendQuery(m)
 }
 
 // Pack the dns.Msg and write to available connections (multicast)

--- a/examples/resolv/client.go
+++ b/examples/resolv/client.go
@@ -18,12 +18,6 @@ var (
 func main() {
 	flag.Parse()
 
-	// Discover all services on the network (e.g. _workstation._tcp)
-	resolver, err := zeroconf.NewResolver(nil)
-	if err != nil {
-		log.Fatalln("Failed to initialize resolver:", err.Error())
-	}
-
 	entries := make(chan *zeroconf.ServiceEntry)
 	go func(results <-chan *zeroconf.ServiceEntry) {
 		for entry := range results {
@@ -34,7 +28,8 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*waitTime))
 	defer cancel()
-	err = resolver.Browse(ctx, *service, *domain, entries)
+	// Discover all services on the network (e.g. _workstation._tcp)
+	err := zeroconf.Browse(ctx, *service, *domain, entries)
 	if err != nil {
 		log.Fatalln("Failed to browse:", err.Error())
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -40,12 +40,8 @@ func TestBasic(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	resolver, err := NewResolver(nil)
-	if err != nil {
-		t.Fatalf("Expected create resolver success, but got %v", err)
-	}
 	entries := make(chan *ServiceEntry, 100)
-	if err := resolver.Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
+	if err := Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
 		t.Fatalf("Expected browse success, but got %v", err)
 	}
 	<-ctx.Done()
@@ -69,11 +65,6 @@ func TestBasic(t *testing.T) {
 }
 
 func TestNoRegister(t *testing.T) {
-	resolver, err := NewResolver(nil)
-	if err != nil {
-		t.Fatalf("Expected create resolver success, but got %v", err)
-	}
-
 	// before register, mdns resolve shuold not have any entry
 	entries := make(chan *ServiceEntry)
 	go func(results <-chan *ServiceEntry) {
@@ -84,7 +75,7 @@ func TestNoRegister(t *testing.T) {
 	}(entries)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	if err := resolver.Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
+	if err := Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
 		t.Fatalf("Expected browse success, but got %v", err)
 	}
 	<-ctx.Done()
@@ -100,12 +91,8 @@ func TestSubtype(t *testing.T) {
 
 		time.Sleep(time.Second)
 
-		resolver, err := NewResolver(nil)
-		if err != nil {
-			t.Fatalf("Expected create resolver success, but got %v", err)
-		}
 		entries := make(chan *ServiceEntry, 100)
-		if err := resolver.Browse(ctx, mdnsSubtype, mdnsDomain, entries); err != nil {
+		if err := Browse(ctx, mdnsSubtype, mdnsDomain, entries); err != nil {
 			t.Fatalf("Expected browse success, but got %v", err)
 		}
 		<-ctx.Done()
@@ -136,12 +123,8 @@ func TestSubtype(t *testing.T) {
 
 		time.Sleep(time.Second)
 
-		resolver, err := NewResolver(nil)
-		if err != nil {
-			t.Fatalf("Expected create resolver success, but got %v", err)
-		}
 		entries := make(chan *ServiceEntry, 100)
-		if err := resolver.Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
+		if err := Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
 			t.Fatalf("Expected browse success, but got %v", err)
 		}
 		<-ctx.Done()


### PR DESCRIPTION
This implements suggestion 1 in #98.

I'm not entirely sure if this is the right way to go, but at least it seems to make the API a lot more intuitive. Also, it allows for a clean shutdown of all Go routines: As soon as `Lookup` / `Browse` return, you can now be certain that no more Go routines are running in the background.