### PR TITLE
Fix: client lookup and browse stop working after 15 minutes

### DIFF
--- a/client.go
+++ b/client.go
@@ -372,6 +372,7 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 4 * time.Second
 	bo.MaxInterval = 60 * time.Second
+	bo.MaxElapsedTime = 0
 	bo.Reset()
 
 	var timer *time.Timer


### PR DESCRIPTION
By default ExponentialBackOff stop after 15 minutes, see [backoff contants](https://pkg.go.dev/github.com/cenkalti/backoff#pkg-constants)

As client Lookup and Browse uses periodicQuery that uses ExponentialBackOff to send probes on the network. After 15 minutes queries are no longer sent so Lookup and Browser can't see any new service.

To fix it we have to set `MaxElapsedTime` to 0 and it will never stop, see [ExponentialBackOff](https://pkg.go.dev/github.com/cenkalti/backoff#ExponentialBackOff)