### PR TITLE
Fix compatibility with some IoT devices using avahi 0.8-rc1 

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -44,6 +44,7 @@ func joinUdp6Multicast(interfaces []net.Interface) (*ipv6.PacketConn, error) {
 	// Join multicast groups to receive announcements
 	pkConn := ipv6.NewPacketConn(udpConn)
 	pkConn.SetControlMessage(ipv6.FlagInterface, true)
+	_ = pkConn.SetMulticastHopLimit(255)
 
 	if len(interfaces) == 0 {
 		interfaces = listMulticastInterfaces()
@@ -75,6 +76,7 @@ func joinUdp4Multicast(interfaces []net.Interface) (*ipv4.PacketConn, error) {
 	// Join multicast groups to receive announcements
 	pkConn := ipv4.NewPacketConn(udpConn)
 	pkConn.SetControlMessage(ipv4.FlagInterface, true)
+	_ = pkConn.SetMulticastTTL(255)
 
 	if len(interfaces) == 0 {
 		interfaces = listMulticastInterfaces()


### PR DESCRIPTION
This fixes browse, lookup and also register not working properly with some devices running with avahi 0.8-rc1

The problem came up with Elli Charger wallboxes, which are using avahi 0.8-rc1 which couldn't be seen using this library and the device also didn't see the service announced with this library. Using avahi 0.8-rc1 on a linux device (ubuntu) does not show the same effects. So something within this device is causing this.

Upping the IPv4 TTL to 255 and the IPv6 HopLimit to 255 solves this. The avahi library also uses these values since almost 18 years and they haven't been changed.

The Multicast DNS RFC has a section about IP TTLs: https://datatracker.ietf.org/doc/html/rfc6762#section-11

> All Multicast DNS responses (including responses sent via unicast) SHOULD be sent with IP TTL set to 255. This is recommended to provide backwards-compatibility with older Multicast DNS queriers (implementing a draft version of this document, posted in February 2004) that check the IP TTL on reception to determine whether the packet originated on the local link. These older queriers discard all packets with TTLs other than 255.
