### PR TITLE
Fix multicast xmit windows

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,9 @@ package zeroconf
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
+	"runtime"
 	"strings"
 	"time"
 
@@ -443,21 +445,37 @@ func (c *client) sendQuery(msg *dns.Msg) error {
 		return err
 	}
 	if c.ipv4conn != nil {
+		// See https://pkg.go.dev/golang.org/x/net/ipv4#pkg-note-BUG
+		// As of Golang 1.18.4
+		// On Windows, the ControlMessage for ReadFrom and WriteTo methods of PacketConn is not implemented.
+		var wcm ipv4.ControlMessage
 		for ifi := range c.ifaces {
-			if err := c.ipv4conn.SetMulticastInterface(&c.ifaces[ifi]); err != nil {
-				// log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
-				continue
+			switch runtime.GOOS {
+			case "darwin", "ios", "linux":
+				wcm.IfIndex = c.ifaces[ifi].Index
+			default:
+				if err := c.ipv4conn.SetMulticastInterface(&c.ifaces[ifi]); err != nil {
+					log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
+				}
 			}
-			c.ipv4conn.WriteTo(buf, nil, ipv4Addr)
+			c.ipv4conn.WriteTo(buf, &wcm, ipv4Addr)
 		}
 	}
 	if c.ipv6conn != nil {
+		// See https://pkg.go.dev/golang.org/x/net/ipv6#pkg-note-BUG
+		// As of Golang 1.18.4
+		// On Windows, the ControlMessage for ReadFrom and WriteTo methods of PacketConn is not implemented.
+		var wcm ipv6.ControlMessage
 		for ifi := range c.ifaces {
-			if err := c.ipv6conn.SetMulticastInterface(&c.ifaces[ifi]); err != nil {
-				// log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
-				continue
+			switch runtime.GOOS {
+			case "darwin", "ios", "linux":
+				wcm.IfIndex = c.ifaces[ifi].Index
+			default:
+				if err := c.ipv6conn.SetMulticastInterface(&c.ifaces[ifi]); err != nil {
+					log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
+				}
 			}
-			c.ipv6conn.WriteTo(buf, nil, ipv6Addr)
+			c.ipv6conn.WriteTo(buf, &wcm, ipv6Addr)
 		}
 	}
 	return nil

--- a/client.go
+++ b/client.go
@@ -443,17 +443,21 @@ func (c *client) sendQuery(msg *dns.Msg) error {
 		return err
 	}
 	if c.ipv4conn != nil {
-		var wcm ipv4.ControlMessage
 		for ifi := range c.ifaces {
-			wcm.IfIndex = c.ifaces[ifi].Index
-			c.ipv4conn.WriteTo(buf, &wcm, ipv4Addr)
+			if err := c.ipv4conn.SetMulticastInterface(&c.ifaces[ifi]); err != nil {
+				// log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
+				continue
+			}
+			c.ipv4conn.WriteTo(buf, nil, ipv4Addr)
 		}
 	}
 	if c.ipv6conn != nil {
-		var wcm ipv6.ControlMessage
 		for ifi := range c.ifaces {
-			wcm.IfIndex = c.ifaces[ifi].Index
-			c.ipv6conn.WriteTo(buf, &wcm, ipv6Addr)
+			if err := c.ipv6conn.SetMulticastInterface(&c.ifaces[ifi]); err != nil {
+				// log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
+				continue
+			}
+			c.ipv6conn.WriteTo(buf, nil, ipv6Addr)
 		}
 	}
 	return nil


### PR DESCRIPTION
Adding to @davidflowerday's [PR](https://github.com/grandcat/zeroconf/pull/81) I've made this platform specific so windows/others uses SetMulticastInterface and linux/darwin uses ControlMessage, I've also updated server.go to include a fix for this problem as well.

I was having issues getting this library to even work on windows, only mDNS services I registered on localhost would show up in my browse/lookup requests, after digging in I found @davidflowerday's PR and a few other comments on other forks.

I've tests this fix on Windows and and linux (WSL) and both seem to be in good shape, I can resolve and register mDNS service both on and off box and see them. I do not have a mac ( Intel or Arm ) to test this on unfortunately.

from @davidflowerday's [PR](https://github.com/grandcat/zeroconf/pull/81)
I'm attempting to use go-chromecast on Windows which leverages this library. Unfortunately, mDNS wasn't working. I was able to fix it by replacing the code that used ControlMessage in WriteTo() with a call to SetMulticastInterface() instead. I think this may be related to issues https://github.com/grandcat/zeroconf/issues/54 https://github.com/grandcat/zeroconf/issues/69 and https://github.com/grandcat/zeroconf/issues/75. I've tested this change on Windows and Linux and I will test on macOS shortly as well. I only changed client.go but it's possible a similar change is needed in server.go as well.

In the [docs for the ipv4 package](https://pkg.go.dev/golang.org/x/net/ipv4#pkg-note-BUG) under Bugs there is this note:

On Windows, the ControlMessage for ReadFrom and WriteTo methods of PacketConn is not implemented.

Additionally, the [ipv4 docs on Multicasting here](https://pkg.go.dev/golang.org/x/net/ipv4#hdr-Multicasting) show an example using SetMulticastInterface() as I've done in this PR which suggests to me that this is an OK way to handle this issue, but if you'd prefer something else I'd be happy to change it.

Thanks for making zeroconf and for considering this PR.