### PR TITLE
Implement LookupStrategy on client.Browse function

### DIFF
--- a/service.go
+++ b/service.go
@@ -70,6 +70,7 @@ type lookupParams struct {
 	ServiceRecord
 	Entries chan<- *ServiceEntry // Entries Channel
 
+	Strategy    LookupStrategy
 	isBrowsing  bool
 	stopProbing chan struct{}
 	once        sync.Once


### PR DESCRIPTION
In some case, only IPv4 or IPv6 is returned. (#27)
For the usecase which require IPv4 address, I added function to specify stratedy to retrieve ipv4/v6 address.
