### PR TITLE
[Bug Fix] Apply default domain before caching derived values

### DIFF
--- a/service_test.go
+++ b/service_test.go
@@ -3,6 +3,7 @@ package zeroconf
 import (
 	"context"
 	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,4 +164,96 @@ func TestSubtype(t *testing.T) {
 			t.Fatalf("Expected port is %d, but got %d", mdnsPort, result.Port)
 		}
 	})
+}
+
+// Test the default domain is applied.
+func TestDefaultDomain(t *testing.T) {
+	t.Run("register", func(t *testing.T) {
+		server, err := Register(mdnsName, mdnsService, "", mdnsPort, []string{"txtv=0", "lo=2", "la=3"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if server == nil {
+			t.Fatal("expect non-nil")
+		}
+		// Check the service record's cached fields
+		sr := server.service.ServiceRecord
+		if strings.Contains(sr.serviceName, "..") {
+			t.Errorf("malformed service name: %s", sr.serviceName)
+		}
+		if strings.Contains(sr.serviceInstanceName, "..") {
+			t.Errorf("malformed service instance name: %s", sr.serviceInstanceName)
+		}
+
+		t.Logf("Published service: %+v", server.service)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		// Wait for context to time out
+		<-ctx.Done()
+
+		t.Log("Shutting down.")
+		server.Shutdown()
+	})
+
+	t.Run("registerproxy", func(t *testing.T) {
+		server, err := RegisterProxy(mdnsName, mdnsService, "", mdnsPort, "localhost", []string{"::1"}, []string{"txtv=0", "lo=2", "la=3"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if server == nil {
+			t.Fatal("expect non-nil")
+		}
+		// Check the service record's cached fields
+		sr := server.service.ServiceRecord
+		if strings.Contains(sr.serviceName, "..") {
+			t.Errorf("malformed service name: %s", sr.serviceName)
+		}
+		if strings.Contains(sr.serviceInstanceName, "..") {
+			t.Errorf("malformed service instance name: %s", sr.serviceInstanceName)
+		}
+
+		t.Logf("Published service: %+v", server.service)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		// Wait for context to time out
+		<-ctx.Done()
+
+		t.Log("Shutting down.")
+		server.Shutdown()
+	})
+}
+
+func TestNewRegisterServiceEntry(t *testing.T) {
+	tests := []struct {
+		name                      string
+		instance, service, domain string
+		port                      int
+		text                      []string
+		err                       bool
+	}{
+		{"minimal", mdnsName, mdnsService, mdnsDomain, mdnsPort, []string{}, false},
+		// Required parameters
+		{"require-instance", "", mdnsService, mdnsDomain, mdnsPort, []string{}, true},
+		{"require-service", mdnsName, "", mdnsDomain, mdnsPort, []string{}, true},
+		{"require-port", mdnsName, mdnsService, mdnsDomain, 0, []string{}, true},
+		// Default domain
+		{"default-domain", mdnsName, mdnsService, "", mdnsPort, []string{}, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			se, err := newRegisterServiceEntry(test.instance, test.service, test.domain, test.port, test.text)
+			if test.err && err == nil {
+				t.Error("expect error")
+			} else if !test.err && err != nil {
+				t.Error(err)
+			}
+			if err == nil && se == nil {
+				t.Error("expect non-nil")
+			}
+		})
+	}
 }


### PR DESCRIPTION
If the domain parameter to Register or RegisterProxy is left empty, a default value of `local.` is used. The default was applied after derived values are cached and thus the default was effectively ignored.