### PR TITLE
feat: support link-local address

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -108,9 +108,16 @@ func listMulticastInterfaces() []net.Interface {
 		if (ifi.Flags & net.FlagUp) == 0 {
 			continue
 		}
-		if (ifi.Flags & net.FlagMulticast) > 0 {
-			interfaces = append(interfaces, ifi)
+		if (ifi.Flags & net.FlagMulticast) == 0 {
+			continue
 		}
+
+		// Prevents bind of the bridge's slave interface.
+		addrs, err := ifi.Addrs()
+		if err != nil || len(addrs) == 0 {
+			continue
+		}
+		interfaces = append(interfaces, ifi)
 	}
 
 	return interfaces

--- a/service.go
+++ b/service.go
@@ -109,6 +109,9 @@ type ServiceEntry struct {
 	TTL      uint32   `json:"ttl"`      // TTL of the service record
 	AddrIPv4 []net.IP `json:"-"`        // Host machine IPv4 address
 	AddrIPv6 []net.IP `json:"-"`        // Host machine IPv6 address
+
+	ReceivedIfIndex int
+	ReceivedSrc     net.Addr
 }
 
 // NewServiceEntry constructs a ServiceEntry.


### PR DESCRIPTION
Fix #51 

In the case of link-local address, the interface must be bound.
Include the received interface in a ServiceEntry.
Additionally, when using a bridge, slave interfaces should not be used.


Use cases: This is a fully working example.
https://github.com/jclab-joseph/libp2p-link-local-demo/tree/ipv6-link-address-with-mdns